### PR TITLE
Improve skill trend loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Generates a trend report for the skills that appear in both 2023 and 2025. The
 script takes the counts for each year, selects the top N shared skills (default
 100) based on combined mentions, and produces a grid of line charts showing the
 change for each skill between the two years. A CSV with the selected skills is
-also written.
+also written. If the provided CSV lacks a `count` column the script looks for a
+file named `parent_<year>.csv` in the same directory, mirroring the structure of
+the public dataset.
 
 Example:
 

--- a/top_100_skill_trends.py
+++ b/top_100_skill_trends.py
@@ -9,11 +9,24 @@ DEFAULT_TOP_N = 100
 
 
 def load_count_data(path: Path) -> pd.DataFrame:
-    """Load a CSV containing columns ``name`` and ``count``."""
+    """Load a CSV containing columns ``name`` and ``count``.
+
+    If ``path`` lacks the required columns, look for a file named
+    ``parent_<original>`` in the same directory.  This mirrors the layout of the
+    example dataset where aggregated counts live in ``parent_2023.csv`` and
+    ``parent_2025.csv`` while ``2023.csv``/``2025.csv`` only contain raw skill
+    rows.
+    """
     df = pd.read_csv(path)
-    if not {'name', 'count'}.issubset(df.columns):
-        raise ValueError(f"Expected columns 'name' and 'count' in {path}")
-    return df[['name', 'count']]
+    if not {"name", "count"}.issubset(df.columns):
+        alt_path = path.with_name(f"parent_{path.name}")
+        if alt_path.exists():
+            df = pd.read_csv(alt_path)
+    if not {"name", "count"}.issubset(df.columns):
+        raise ValueError(
+            f"Expected columns 'name' and 'count' in {path} or {alt_path}"
+        )
+    return df[["name", "count"]]
 
 
 def get_common_top_skills(


### PR DESCRIPTION
## Summary
- handle missing `count` column by falling back to `parent_<year>.csv`
- document fallback behaviour in README

## Testing
- `python -m py_compile *.py`