### PR TITLE
Fix formatting of output CSVs

### DIFF
--- a/top_100_growth_buckets.py
+++ b/top_100_growth_buckets.py
@@ -49,6 +49,15 @@ def bucket_skills(
             subset = subset.sort_values("pct_change").head(top_n)
         else:
             subset = subset.sort_values("pct_change", ascending=False).head(top_n)
+
+        # Format counts as integers and percentage change with a trailing % sign
+        subset["count_2023"] = subset["count_2023"].round().astype("Int64")
+        subset["count_2025"] = subset["count_2025"].round().astype("Int64")
+        subset["pct_change"] = (
+            subset["pct_change"].round().astype("Int64").map(
+                lambda x: f"{x}%" if pd.notna(x) else ""
+            )
+        )
         result[label] = subset[["name", "pct_change", "count_2023", "count_2025"]]
 
     return result

--- a/top_100_skill_trends.py
+++ b/top_100_skill_trends.py
@@ -103,6 +103,8 @@ def main() -> None:
 
     # Round percentage change and add a trailing percent sign for the CSV
     csv_df = top_common.copy()
+    csv_df["count_2023"] = csv_df["count_2023"].round().astype("Int64")
+    csv_df["count_2025"] = csv_df["count_2025"].round().astype("Int64")
     csv_df["pct_change"] = (
         csv_df["pct_change"].round().astype("Int64").map(
             lambda x: f"{x}%" if pd.notna(x) else ""


### PR DESCRIPTION
## Summary
- ensure counts are integers and pct change uses percent sign for growth buckets
- apply the same formatting to skill trends CSV

## Testing
- `python -m py_compile sandbox/top_100_growth_buckets.py sandbox/top_100_skill_trends.py`