### PR TITLE
Fix pct_change formatting in growth buckets

### DIFF
--- a/top_100_growth_buckets.py
+++ b/top_100_growth_buckets.py
@@ -53,10 +53,8 @@ def bucket_skills(
         # Format counts as integers and percentage change with a trailing % sign
         subset["count_2023"] = subset["count_2023"].round().astype("Int64")
         subset["count_2025"] = subset["count_2025"].round().astype("Int64")
-        subset["pct_change"] = (
-            subset["pct_change"].round().astype("Int64").map(
-                lambda x: f"{x}%" if pd.notna(x) else ""
-            )
+        subset["pct_change"] = subset["pct_change"].round().map(
+            lambda x: f"{int(x)}%" if pd.notna(x) else ""
         )
         result[label] = subset[["name", "pct_change", "count_2023", "count_2025"]]
 


### PR DESCRIPTION
## Summary
- avoid using the `Int64` dtype when formatting pct_change

## Testing
- `python -m py_compile *.py`
